### PR TITLE
Extend lexicons to support Open Community Notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: main
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/lexicons/label.json
+++ b/lexicons/label.json
@@ -41,7 +41,7 @@
                     },
                     "note": {
                         "type": "string",
-                        "description": "The full text of any annotation associated with this label. Only for `readers-added-context` labels."
+                        "description": "The full text of any annotation associated with this label. Only for 'needs-context' labels."
                     },
                     "proposal": {
                         "type": "ref",

--- a/lexicons/label.json
+++ b/lexicons/label.json
@@ -7,7 +7,7 @@
             "key": "tid",
             "record": {
                 "type": "object",
-                "description": "Replicates `com.atproto.label.defs#label, but as a concrete record type",
+                "description": "Like `com.atproto.label.defs#label', but as a concrete record type, and with additional optional fields 'note' and 'proposal'.",
                 "required": [
                     "src",
                     "uri",
@@ -38,6 +38,15 @@
                         "type": "string",
                         "maxLength": 128,
                         "description": "The short string name of the value or type of this label."
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": "The full text of any annotation associated with this label. Only for `readers-added-context` labels."
+                    },
+                    "proposal": {
+                        "type": "ref",
+                        "ref": "com.atproto.repo.strongRef",
+                        "description": "A strong reference to the proposal that created this label."
                     },
                     "neg": {
                         "type": "boolean",

--- a/lexicons/proposal.json
+++ b/lexicons/proposal.json
@@ -46,7 +46,7 @@
                     },
                     "note": {
                         "type": "string",
-                        "description": "For 'post_label' proposals where 'val' is 'needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post."
+                        "description": "For 'post_label' proposals where 'val' is 'needs-context', the full text of any proposed annotation (e.g. community note) to be shown below the post."
                     },
                     "reasons": {
                         "type": "array",
@@ -68,19 +68,10 @@
                         "type": "string",
                         "description": "The persistent, anonymous identifier for the user creating the proposal."
                     },
-                    "neg": {
-                        "type": "boolean",
-                        "description": "If true, this is a negation of a proposal, overwriting a previous proposal."
-                    },
                     "cts": {
                         "type": "string",
                         "format": "datetime",
                         "description": "Timestamp when this proposal was created."
-                    },
-                    "exp": {
-                        "type": "string",
-                        "format": "datetime",
-                        "description": "Timestamp at which this proposal expires (no longer applies)."
                     },
                     "sig": {
                         "type": "bytes",

--- a/lexicons/proposal.json
+++ b/lexicons/proposal.json
@@ -7,7 +7,7 @@
             "key": "tid",
             "record": {
                 "type": "object",
-                "description": "Some proposal that refers to another ATproto record.  Similar to `com.atproto.proposal.defs#label, but as a concrete record type.",
+                "description": "A proposed moderation action (e.g. adding a label or annotation to a post). Refers to some other resource via URI (e.g. an atproto post). Superset of 'com.atproto.proposal.defs#label.",
                 "required": [
                     "typ",
                     "src",
@@ -22,7 +22,7 @@
                     },
                     "typ": {
                         "type": "string",
-                        "description": "the type of proposal, currently expected values are 'allowed_user' or 'post_proposal'"
+                        "description": "The type of moderation action being proposed. Currently expected values are 'allowed_user' or 'post_label'"
                     },
                     "src": {
                         "type": "string",
@@ -42,7 +42,31 @@
                     "val": {
                         "type": "string",
                         "maxLength": 128,
-                        "description": "The short string name of the value or type of this proposal."
+                        "description": "For 'post_label' proposals, the short string name of the value of the proposed label."
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": "For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post."
+                    },
+                    "reasons": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "knownValues": [
+                                "factual_error",
+                                "altered_media",
+                                "outdated_information",
+                                "misrepresentation_or_missing_context",
+                                "unverified_claim_as_fact",
+                                "joke_or_satire",
+                                "other"
+                            ]
+                        },
+                        "description": "An optional array of predefined reasons justifying the moderation action."
+                    },
+                    "aid": {
+                        "type": "string",
+                        "description": "The persistent, anonymous identifier for the user creating the proposal."
                     },
                     "neg": {
                         "type": "boolean",

--- a/lexicons/proposal.json
+++ b/lexicons/proposal.json
@@ -46,7 +46,7 @@
                     },
                     "note": {
                         "type": "string",
-                        "description": "For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post."
+                        "description": "For 'post_label' proposals where 'val' is 'needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post."
                     },
                     "reasons": {
                         "type": "array",

--- a/lexicons/vote.json
+++ b/lexicons/vote.json
@@ -7,7 +7,7 @@
             "key": "tid",
             "record": {
                 "type": "object",
-                "description": "a vote record, representing a user's agreement or disagreement with the referenced record, be it a label, post, or user.",
+                "description": "A vote record, representing a user's approval or disapproval with the referenced resource. The resource my be a pmsky proposal, a bluesky post, a web page, or anything that can be agreed or disagreed with.",
                 "properties": {
                     "src": {
                         "type": "string",
@@ -26,7 +26,35 @@
                     },
                     "val": {
                         "type": "integer",
-                        "description": "The value of the vote, either +1 or -1"
+                        "description": "The value of the vote. The exact meaning depends on what is being voted on, but generally '+1' means 'approval', -1 means 'disapproval', and 0 indicates 'neutrality'."
+                    },
+                    "reasons": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "knownValues": [
+                                "cites_high_quality_sources",
+                                "is_clear",
+                                "addresses_claim",
+                                "provides_important_context",
+                                "is_unbiased",
+                                "sources_missing_or_unreliable",
+                                "sources_dont_support_note",
+                                "is_incorrect",
+                                "is_opinion_or_speculation",
+                                "is_hard_to_understand",
+                                "is_off_topic_or_irrelevant",
+                                "is_argumentative_or_biased",
+                                "note_not_needed",
+                                "is_spam_harassment_or_abuse",
+                                "other"
+                            ]
+                        },
+                        "description": "An optional array of predefined reasons justifying the rating."
+                    },
+                    "aid": {
+                        "type": "string",
+                        "description": "The persistent, anonymous identifier for the user casting the vote."
                     },
                     "cts": {
                         "type": "string",

--- a/src/backfiller.ts
+++ b/src/backfiller.ts
@@ -62,8 +62,11 @@ export class Backfiller {
   }
 
   async saveLabels(labels: Proposal[]) {
-    // this.logger.trace(labels, "saving labels");
-    await this.db
+   if (labels.length === 0) {
+      return
+   }
+   // this.logger.trace(labels, "saving labels");
+   await this.db
       .insertInto("proposals")
       .values(labels)
       .onConflict((oc) => oc.column("rkey").doNothing())
@@ -71,6 +74,9 @@ export class Backfiller {
   }
 
   async saveLabelVotes(votes: ProposalVote[]) {
+    if (votes.length === 0) {
+      return
+    }
     // this.logger.trace(votes, "saving votes");
     await this.db
       .insertInto("proposal_votes")

--- a/src/lexicon/lexicons.ts
+++ b/src/lexicon/lexicons.ts
@@ -285,7 +285,7 @@ export const schemaDict = {
             note: {
               type: 'string',
               description:
-                'The full text of any annotation associated with this label. Only for `needs-context` labels.',
+                'The full text of any annotation associated with this label. Only for 'needs-context' labels.',
             },
             proposal: {
               type: 'ref',

--- a/src/lexicon/lexicons.ts
+++ b/src/lexicon/lexicons.ts
@@ -285,7 +285,7 @@ export const schemaDict = {
             note: {
               type: 'string',
               description:
-                'The full text of any annotation associated with this label. Only for `readers-added-context` labels.',
+                'The full text of any annotation associated with this label. Only for `needs-context` labels.',
             },
             proposal: {
               type: 'ref',
@@ -366,7 +366,7 @@ export const schemaDict = {
             note: {
               type: 'string',
               description:
-                "For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post.",
+                "For 'post_label' proposals where 'val' is '`needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post.",
             },
             reasons: {
               type: 'array',

--- a/src/lexicon/lexicons.ts
+++ b/src/lexicon/lexicons.ts
@@ -252,7 +252,7 @@ export const schemaDict = {
         record: {
           type: 'object',
           description:
-            'Replicates `com.atproto.label.defs#label, but as a concrete record type',
+            "Like `com.atproto.label.defs#label', but as a concrete record type, and with additional optional fields 'note' and 'proposal'.",
           required: ['src', 'uri', 'val', 'cts'],
           properties: {
             ver: {
@@ -281,6 +281,17 @@ export const schemaDict = {
               maxLength: 128,
               description:
                 'The short string name of the value or type of this label.',
+            },
+            note: {
+              type: 'string',
+              description:
+                'The full text of any annotation associated with this label. Only for `readers-added-context` labels.',
+            },
+            proposal: {
+              type: 'ref',
+              ref: 'lex:com.atproto.repo.strongRef',
+              description:
+                'A strong reference to the proposal that created this label.',
             },
             neg: {
               type: 'boolean',
@@ -317,7 +328,7 @@ export const schemaDict = {
         record: {
           type: 'object',
           description:
-            'Some proposal that refers to another ATproto record.  Similar to `com.atproto.proposal.defs#label, but as a concrete record type.',
+            "A proposed moderation action (e.g. adding a label or annotation to a post). Refers to some other resource via URI (e.g. an atproto post). Superset of 'com.atproto.proposal.defs#label.",
           required: ['typ', 'src', 'uri', 'val', 'cts'],
           properties: {
             ver: {
@@ -327,7 +338,7 @@ export const schemaDict = {
             typ: {
               type: 'string',
               description:
-                "the type of proposal, currently expected values are 'allowed_user' or 'post_proposal'",
+                "The type of moderation action being proposed. Currently expected values are 'allowed_user' or 'post_label'",
             },
             src: {
               type: 'string',
@@ -350,7 +361,34 @@ export const schemaDict = {
               type: 'string',
               maxLength: 128,
               description:
-                'The short string name of the value or type of this proposal.',
+                "For 'post_label' proposals, the short string name of the value of the proposed label.",
+            },
+            note: {
+              type: 'string',
+              description:
+                "For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post.",
+            },
+            reasons: {
+              type: 'array',
+              items: {
+                type: 'string',
+                knownValues: [
+                  'factual_error',
+                  'altered_media',
+                  'outdated_information',
+                  'misrepresentation_or_missing_context',
+                  'unverified_claim_as_fact',
+                  'joke_or_satire',
+                  'other',
+                ],
+              },
+              description:
+                'An optional array of predefined reasons justifying the moderation action.',
+            },
+            aid: {
+              type: 'string',
+              description:
+                'The persistent, anonymous identifier for the user creating the proposal.',
             },
             neg: {
               type: 'boolean',
@@ -408,7 +446,7 @@ export const schemaDict = {
         record: {
           type: 'object',
           description:
-            "a vote record, representing a user's agreement or disagreement with the referenced record, be it a label, post, or user.",
+            "A vote record, representing a user's approval or disapproval with the referenced resource. The resource my be a pmsky proposal, a bluesky post, a web page, or anything that can be agreed or disagreed with.",
           properties: {
             src: {
               type: 'string',
@@ -430,7 +468,38 @@ export const schemaDict = {
             },
             val: {
               type: 'integer',
-              description: 'The value of the vote, either +1 or -1',
+              description:
+                "The value of the vote. The exact meaning depends on what is being voted on, but generally '+1' means 'approval', -1 means 'disapproval', and 0 indicates 'neutrality'.",
+            },
+            reasons: {
+              type: 'array',
+              items: {
+                type: 'string',
+                knownValues: [
+                  'cites_high_quality_sources',
+                  'is_clear',
+                  'addresses_claim',
+                  'provides_important_context',
+                  'is_unbiased',
+                  'sources_missing_or_unreliable',
+                  'sources_dont_support_note',
+                  'is_incorrect',
+                  'is_opinion_or_speculation',
+                  'is_hard_to_understand',
+                  'is_off_topic_or_irrelevant',
+                  'is_argumentative_or_biased',
+                  'note_not_needed',
+                  'is_spam_harassment_or_abuse',
+                  'other',
+                ],
+              },
+              description:
+                'An optional array of predefined reasons justifying the rating.',
+            },
+            aid: {
+              type: 'string',
+              description:
+                'The persistent, anonymous identifier for the user casting the vote.',
             },
             cts: {
               type: 'string',

--- a/src/lexicon/lexicons.ts
+++ b/src/lexicon/lexicons.ts
@@ -285,7 +285,7 @@ export const schemaDict = {
             note: {
               type: 'string',
               description:
-                'The full text of any annotation associated with this label. Only for 'needs-context' labels.',
+                "The full text of any annotation associated with this label. Only for 'needs-context' labels.",
             },
             proposal: {
               type: 'ref',
@@ -366,7 +366,7 @@ export const schemaDict = {
             note: {
               type: 'string',
               description:
-                "For 'post_label' proposals where 'val' is '`needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post.",
+                "For 'post_label' proposals where 'val' is 'needs-context', the full text of any proposed annotation (e.g. community note) to be shown below the post.",
             },
             reasons: {
               type: 'array',
@@ -390,21 +390,10 @@ export const schemaDict = {
               description:
                 'The persistent, anonymous identifier for the user creating the proposal.',
             },
-            neg: {
-              type: 'boolean',
-              description:
-                'If true, this is a negation of a proposal, overwriting a previous proposal.',
-            },
             cts: {
               type: 'string',
               format: 'datetime',
               description: 'Timestamp when this proposal was created.',
-            },
-            exp: {
-              type: 'string',
-              format: 'datetime',
-              description:
-                'Timestamp at which this proposal expires (no longer applies).',
             },
             sig: {
               type: 'bytes',

--- a/src/lexicon/types/social/pmsky/label.ts
+++ b/src/lexicon/types/social/pmsky/label.ts
@@ -5,8 +5,9 @@ import { ValidationResult, BlobRef } from '@atproto/lexicon'
 import { lexicons } from '../../../lexicons'
 import { isObj, hasProp } from '../../../util'
 import { CID } from 'multiformats/cid'
+import * as ComAtprotoRepoStrongRef from '../../com/atproto/repo/strongRef'
 
-/** Replicates `com.atproto.label.defs#label, but as a concrete record type */
+/** Like `com.atproto.label.defs#label', but as a concrete record type, and with additional optional fields 'note' and 'proposal'. */
 export interface Record {
   /** The AT Protocol version of the label object. */
   ver?: number
@@ -18,6 +19,9 @@ export interface Record {
   cid?: string
   /** The short string name of the value or type of this label. */
   val: string
+  /** The full text of any annotation associated with this label. Only for `readers-added-context` labels. */
+  note?: string
+  proposal?: ComAtprotoRepoStrongRef.Main
   /** If true, this is a negation label, overwriting a previous label. */
   neg?: boolean
   /** Timestamp when this label was created. */

--- a/src/lexicon/types/social/pmsky/label.ts
+++ b/src/lexicon/types/social/pmsky/label.ts
@@ -19,7 +19,7 @@ export interface Record {
   cid?: string
   /** The short string name of the value or type of this label. */
   val: string
-  /** The full text of any annotation associated with this label. Only for `readers-added-context` labels. */
+  /** The full text of any annotation associated with this label. Only for 'needs-context' labels. */
   note?: string
   proposal?: ComAtprotoRepoStrongRef.Main
   /** If true, this is a negation label, overwriting a previous label. */

--- a/src/lexicon/types/social/pmsky/proposal.ts
+++ b/src/lexicon/types/social/pmsky/proposal.ts
@@ -20,7 +20,7 @@ export interface Record {
   cid?: string
   /** For 'post_label' proposals, the short string name of the value of the proposed label. */
   val: string
-  /** For 'post_label' proposals where 'val' is '`needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post. */
+  /** For 'post_label' proposals where 'val' is 'needs-context', the full text of any proposed annotation (e.g. community note) to be shown below the post. */
   note?: string
   /** An optional array of predefined reasons justifying the moderation action. */
   reasons?:
@@ -34,12 +34,8 @@ export interface Record {
     | (string & {})[]
   /** The persistent, anonymous identifier for the user creating the proposal. */
   aid?: string
-  /** If true, this is a negation of a proposal, overwriting a previous proposal. */
-  neg?: boolean
   /** Timestamp when this proposal was created. */
   cts: string
-  /** Timestamp at which this proposal expires (no longer applies). */
-  exp?: string
   /** Signature of dag-cbor encoded proposal. */
   sig?: Uint8Array
   [k: string]: unknown

--- a/src/lexicon/types/social/pmsky/proposal.ts
+++ b/src/lexicon/types/social/pmsky/proposal.ts
@@ -6,11 +6,11 @@ import { lexicons } from '../../../lexicons'
 import { isObj, hasProp } from '../../../util'
 import { CID } from 'multiformats/cid'
 
-/** Some proposal that refers to another ATproto record.  Similar to `com.atproto.proposal.defs#label, but as a concrete record type. */
+/** A proposed moderation action (e.g. adding a label or annotation to a post). Refers to some other resource via URI (e.g. an atproto post). Superset of 'com.atproto.proposal.defs#label. */
 export interface Record {
   /** The AT Protocol version of the proposal object. */
   ver?: number
-  /** the type of proposal, currently expected values are 'allowed_user' or 'post_proposal' */
+  /** The type of moderation action being proposed. Currently expected values are 'allowed_user' or 'post_label' */
   typ: string
   /** DID of the actor who created this proposal. */
   src: string
@@ -18,8 +18,22 @@ export interface Record {
   uri: string
   /** Optionally, CID specifying the specific version of 'uri' resource this proposal applies to. */
   cid?: string
-  /** The short string name of the value or type of this proposal. */
+  /** For 'post_label' proposals, the short string name of the value of the proposed label. */
   val: string
+  /** For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post. */
+  note?: string
+  /** An optional array of predefined reasons justifying the moderation action. */
+  reasons?:
+    | 'factual_error'
+    | 'altered_media'
+    | 'outdated_information'
+    | 'misrepresentation_or_missing_context'
+    | 'unverified_claim_as_fact'
+    | 'joke_or_satire'
+    | 'other'
+    | (string & {})[]
+  /** The persistent, anonymous identifier for the user creating the proposal. */
+  aid?: string
   /** If true, this is a negation of a proposal, overwriting a previous proposal. */
   neg?: boolean
   /** Timestamp when this proposal was created. */

--- a/src/lexicon/types/social/pmsky/proposal.ts
+++ b/src/lexicon/types/social/pmsky/proposal.ts
@@ -20,7 +20,7 @@ export interface Record {
   cid?: string
   /** For 'post_label' proposals, the short string name of the value of the proposed label. */
   val: string
-  /** For 'post_label' proposals where 'val' is '`readers-added-context', the full text of the proposed annotation (e.g. community note) to be shown below the post. */
+  /** For 'post_label' proposals where 'val' is '`needs-context', the full text of the proposed annotation (e.g. community note) to be shown below the post. */
   note?: string
   /** An optional array of predefined reasons justifying the moderation action. */
   reasons?:

--- a/src/lexicon/types/social/pmsky/vote.ts
+++ b/src/lexicon/types/social/pmsky/vote.ts
@@ -6,7 +6,7 @@ import { lexicons } from '../../../lexicons'
 import { isObj, hasProp } from '../../../util'
 import { CID } from 'multiformats/cid'
 
-/** a vote record, representing a user's agreement or disagreement with the referenced record, be it a label, post, or user. */
+/** A vote record, representing a user's approval or disapproval with the referenced resource. The resource my be a pmsky proposal, a bluesky post, a web page, or anything that can be agreed or disagreed with. */
 export interface Record {
   /** the account creating the vote, not necessarily the same as the user who voted */
   src: string
@@ -14,8 +14,28 @@ export interface Record {
   uri: string
   /** Optionally, CID specifying the specific version of 'uri' resource this vote applies to. */
   cid?: string
-  /** The value of the vote, either +1 or -1 */
+  /** The value of the vote. The exact meaning depends on what is being voted on, but generally '+1' means 'approval', -1 means 'disapproval', and 0 indicates 'neutrality'. */
   val: number
+  /** An optional array of predefined reasons justifying the rating. */
+  reasons?:
+    | 'cites_high_quality_sources'
+    | 'is_clear'
+    | 'addresses_claim'
+    | 'provides_important_context'
+    | 'is_unbiased'
+    | 'sources_missing_or_unreliable'
+    | 'sources_dont_support_note'
+    | 'is_incorrect'
+    | 'is_opinion_or_speculation'
+    | 'is_hard_to_understand'
+    | 'is_off_topic_or_irrelevant'
+    | 'is_argumentative_or_biased'
+    | 'note_not_needed'
+    | 'is_spam_harassment_or_abuse'
+    | 'other'
+    | (string & {})[]
+  /** The persistent, anonymous identifier for the user casting the vote. */
+  aid?: string
   /** Timestamp when this vote was created. */
   cts: string
   /** Signature of dag-cbor encoded vote. */


### PR DESCRIPTION
feat(lexicon): extend lexicons to supprt Open Community Notes

https://github.com/johnwarden/open-community-notes/tree/master/proposals/001-architecture

- **proposal.json:**
  - Added optional `note`, `reasons`, and `aid` (anonymous user id) fields..
  - Defined a `knownValues` list for `reasons` (e.g., 'factual_error', 'altered_media'), based on the reason's in X's community notes.

- **vote.json:**
  - Added optional `reasons` and `aid` fields.
  - Updated the `val` field description to support OCN rating states (+1: helpful, -1: not_helpful, 0: somewhat_helpful).
  - Defined a `knownValues` list for `reasons`.

- **label.json:**
  - Added an optional `note` field to carry the final text of a community note.
  - Added an optional `proposal` field (strongRef) to create a verifiable link from a published label back to the proposal that originated it.

All new fields are optional to ensure no breaking changes for existing applications using the pmsky lexicon.